### PR TITLE
Change file mode to 700 for ~/.ssh directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
     owner: "{{ operator_user }}"
     group: "{{ operator_group }}"
     state: directory
-    mode: 0750
+    mode: 0700
   become: true
 
 - name: Set ssh authorized keys


### PR DESCRIPTION
The correct mode is 700 for .ssh/.